### PR TITLE
Extract lock scheduler logic into a mixin.

### DIFF
--- a/django_celerybeat_lock/__init__.py
+++ b/django_celerybeat_lock/__init__.py
@@ -1,2 +1,2 @@
 
-from .scheduler import LockedPersistentScheduler
+from .scheduler import LockedPersistentScheduler, LockedSchedulerMixin


### PR DESCRIPTION
Hey there, thank you for making this library!

In this PR I've extracted the lock logic into its own mixin to allow using it in other schedulers easily, eg:

```py
from django_celery_beat.schedulers import DatabaseScheduler
from django_celerybeat_lock import LockedSchedulerMixin


class LockedDatabaseScheduler(LockedSchedulerMixin, DatabaseScheduler):
    pass
```

Since there is nothing specific to the `PersistentScheduler` in the code I figured there's no reason not to make it available for other usage patterns. :)

Feedback welcome!